### PR TITLE
Automate vCPU affinity setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,13 +1401,25 @@ dependencies = [
  "anyhow",
  "cargo_metadata 0.15.4",
  "clap",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "memmap2",
  "regex",
  "semver",
  "serde",
  "serde_json",
  "tempfile",
+]
+
+[[package]]
+name = "libbpf-rs"
+version = "0.24.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93edd9cd673087fa7518fd63ad6c87be2cd9b4e35034b1873f3e3258c018275b"
+dependencies = [
+ "bitflags 2.6.0",
+ "libbpf-sys",
+ "libc",
+ "vsprintf",
 ]
 
 [[package]]
@@ -2266,7 +2278,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "log",
  "scx_stats",
  "scx_stats_derive",
@@ -2283,7 +2295,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "log",
  "scx_stats",
  "scx_stats_derive",
@@ -2305,7 +2317,7 @@ dependencies = [
  "gpoint",
  "hex",
  "itertools",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
  "ordered-float",
@@ -2331,7 +2343,7 @@ dependencies = [
  "fastrand",
  "fb_procfs",
  "lazy_static",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
  "once_cell",
@@ -2374,7 +2386,7 @@ dependencies = [
  "fb_procfs",
  "itertools",
  "lazy_static",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
  "maplit",
@@ -2395,7 +2407,7 @@ dependencies = [
  "ctrlc",
  "fb_procfs",
  "lazy_static",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
  "ordered-float",
@@ -2414,11 +2426,33 @@ version = "1.0.10"
 dependencies = [
  "anyhow",
  "ctrlc",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "plain",
  "scx_rustland_core",
  "scx_utils",
+]
+
+[[package]]
+name = "scx_rorke"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "crossbeam",
+ "ctrlc",
+ "lazy_static",
+ "libbpf-rs 0.24.8",
+ "libc",
+ "log",
+ "plain",
+ "scx_stats",
+ "scx_stats_derive",
+ "scx_utils",
+ "serde",
+ "serde_json",
+ "simplelog",
 ]
 
 [[package]]
@@ -2429,7 +2463,7 @@ dependencies = [
  "clap",
  "ctrlc",
  "fb_procfs",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
  "ordered-float",
@@ -2447,7 +2481,7 @@ name = "scx_rustland_core"
 version = "2.2.9"
 dependencies = [
  "anyhow",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "plain",
  "scx_utils",
@@ -2465,7 +2499,7 @@ dependencies = [
  "crossbeam",
  "ctrlc",
  "fb_procfs",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
  "ordered-float",
@@ -2515,7 +2549,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "ctrlc",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "log",
  "scx_stats",
  "scx_stats_derive",
@@ -2535,7 +2569,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "libbpf-cargo",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libbpf-sys",
  "libc",
  "log",
@@ -2578,7 +2612,7 @@ dependencies = [
  "hashbrown 0.15.2",
  "json5",
  "lazy_static",
- "libbpf-rs",
+ "libbpf-rs 0.25.0-beta.1",
  "libc",
  "log",
  "log-panics",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,6 +1841,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "perf-event-open-sys"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fa97b8f69404e792c384914dbe6ffc298586cca534e1c1c410e02f7cd13cfe"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "perf-event-open-sys2"
 version = "5.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2444,8 +2453,10 @@ dependencies = [
  "ctrlc",
  "lazy_static",
  "libbpf-rs 0.24.8",
+ "libbpf-sys",
  "libc",
  "log",
+ "perf-event-open-sys",
  "plain",
  "scx_stats",
  "scx_stats_derive",

--- a/scheds/rust/scx_rorke/Cargo.toml
+++ b/scheds/rust/scx_rorke/Cargo.toml
@@ -26,6 +26,8 @@ serde_json = "1.0.128"
 lazy_static = "1.5.0"
 crossbeam = "0.8.4"
 chrono = "0.4.38"
+libbpf-sys = "1.4.6"
+perf-event-open-sys = "5.0.0"
 
 [build-dependencies]
 scx_utils = { path = "../../../rust/scx_utils", version = "1.0.4" }

--- a/scheds/rust/scx_rorke/scripts/make_vm_config.py
+++ b/scheds/rust/scx_rorke/scripts/make_vm_config.py
@@ -90,10 +90,11 @@ def main():
 
         vcpu_pids = get_vcpu_pids(vm_name, vm_pid)
 
-        output.append({"vm_id": vm_pid, "vcpus": vcpu_pids})
+        output.append({"vm_name": vm_name, "vm_id": vm_pid, "vcpus": vcpu_pids})
 
     print(json.dumps(output, indent=4))
 
 
 if __name__ == "__main__":
     main()
+

--- a/scheds/rust/scx_rorke/scripts/make_vm_config.py
+++ b/scheds/rust/scx_rorke/scripts/make_vm_config.py
@@ -14,7 +14,7 @@ def get_vm_pid(vm_name):
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=True
         )
         for line in result.stdout.strip().split("\n"):
-            if vm_name in line:
+            if f"-name guest={vm_name}," in line:
                 pid = int(line.strip().split()[0])
                 return pid
     except subprocess.CalledProcessError as e:

--- a/scheds/rust/scx_rorke/src/bpf/intf.h
+++ b/scheds/rust/scx_rorke/src/bpf/intf.h
@@ -33,8 +33,7 @@ enum consts {
 };
 
 struct sched_data {
-	u64 instr;
-	u64 cycles;
+	u64 llc_misses;
 };
 
 /*
@@ -44,8 +43,9 @@ struct cpu_ctx {
   u64 last_running;
   u64 preempted;
   u64 vm_id;
-  struct sched_data cur_data; // data for the current preemption slice
-  struct sched_data total_data; // total data for at most timer_interval_update_period slices
+  u64 timer_interval_ns;
+  u64 preemptions_remaining;
+  struct sched_data data;
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_rorke/src/bpf/intf.h
+++ b/scheds/rust/scx_rorke/src/bpf/intf.h
@@ -30,10 +30,17 @@ typedef unsigned long long u64;
 enum consts {
   MAX_CPUS = 128,
   MAX_VMS = 16,
+  WINDOW_SIZE = 3,
 };
 
 struct sched_data {
 	u64 llc_misses;
+	u64 interval_ns;
+};
+
+struct data_window {
+	struct sched_data window[WINDOW_SIZE];
+	u32 current;
 };
 
 /*
@@ -45,7 +52,7 @@ struct cpu_ctx {
   u64 vm_id;
   u64 timer_interval_ns;
   u64 preemptions_remaining;
-  struct sched_data data;
+  struct data_window data;
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_rorke/src/bpf/intf.h
+++ b/scheds/rust/scx_rorke/src/bpf/intf.h
@@ -32,6 +32,11 @@ enum consts {
   MAX_VMS = 16,
 };
 
+struct sched_data {
+	u64 instr;
+	u64 cycles;
+};
+
 /*
  * Per-CPU context.
  */
@@ -39,6 +44,7 @@ struct cpu_ctx {
   u64 last_running;
   u64 preempted;
   u64 vm_id;
+  struct sched_data data;
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_rorke/src/bpf/intf.h
+++ b/scheds/rust/scx_rorke/src/bpf/intf.h
@@ -44,7 +44,8 @@ struct cpu_ctx {
   u64 last_running;
   u64 preempted;
   u64 vm_id;
-  struct sched_data data;
+  struct sched_data cur_data; // data for the current preemption slice
+  struct sched_data total_data; // total data for at most timer_interval_update_period slices
 };
 
 #endif /* __INTF_H */

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -41,13 +41,68 @@ volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
 const u64 min_timer_interval_ns = 100000; // 100us
 const u64 max_timer_interval_ns = 1000000; // 1ms
 const u64 switch_time_ns = 5000000000; // 5s
-const u64 llc_miss_latency_ns = 2000; // 2us
+const u64 llc_miss_latency_ns = 4000; // 4us
 
 /*
  * Compute timer interval based on IPC.
  */
-static u64 compute_timer_interval_ns(struct sched_data* data) {
-  return 0;
+static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_data* data) {
+  /*
+   * rho = llc_misses * llc_miss_latency / switch_time
+   * oversubcription_ratio = nr_vcpus / nr_cpus
+   * if rho >= 1.0:
+   *     return max_timer_interval_ns
+   * chain_latency = (oversubcription_ratio - 1) * old_timer_interval_ns * rho / (1 - rho)
+   * new_timer_interval_ns = chain_latency * 1.2
+   * if new_timer_interval_ns < min_timer_interval_ns:
+   *     new_timer_interval_ns = min_timer_interval_ns
+   * if new_timer_interval_ns > max_timer_interval_ns:
+   *     new_timer_interval_ns = max_timer_interval_ns
+   * return new_timer_interval_ns
+   */
+
+  // Use Q6 fixed-point (scale = 1,000,000)
+  static const u64 SCALE = 1000000;
+  static const u64 EPSILON_FP = 200000; // 0.2 in fixed-point
+  u64 llc_misses = data->llc_misses;
+  u64 rho_fp = 0;
+  if (switch_time_ns > 0)
+    rho_fp = (llc_misses * llc_miss_latency_ns * SCALE) / switch_time_ns;
+
+  // oversubscription_ratio = nr_vcpus / nr_cpus (fixed-point)
+  u64 oversub_fp = 0;
+  if (nr_cpus > 0)
+    oversub_fp = ((u64)nr_vcpus) * SCALE / nr_cpus;
+
+  // If rho >= 1.0 (i.e., rho_fp >= SCALE)
+  if (rho_fp >= SCALE)
+    return max_timer_interval_ns;
+
+  // chain_latency = (oversubscription_ratio - 1) * old_timer_interval_ns * rho / (1 - rho)
+  // All in fixed-point
+  s64 oversub_minus1_fp = (s64)oversub_fp - (s64)SCALE;
+
+  // numerator: (oversub_minus1_fp * old_timer_interval_ns * rho_fp)
+  // denominator: (SCALE - rho_fp)
+  u64 denominator = SCALE - rho_fp;
+  u64 chain_latency = 0;
+  if (denominator > 0) {
+    u64 numerator = (u64)(oversub_minus1_fp) * old_timer_interval_ns * rho_fp;
+    chain_latency = numerator / denominator;
+  }
+
+  // new_timer_interval_ns = chain_latency * 1.2 (fixed-point: 1.2 = 1200000)
+  u64 new_timer_interval_ns = (chain_latency * (SCALE + EPSILON_FP)) / SCALE / SCALE;
+
+  info("compute_timer_interval_ns: llc_misses=%llu, rho_fp=%llu, "
+		   "oversub_fp=%llu, chain_latency=%llu, new_timer_interval_ns=%llu",
+	   llc_misses, rho_fp, oversub_fp, chain_latency, new_timer_interval_ns);
+
+  if (new_timer_interval_ns < min_timer_interval_ns)
+    new_timer_interval_ns = min_timer_interval_ns;
+  if (new_timer_interval_ns > max_timer_interval_ns)
+    new_timer_interval_ns = max_timer_interval_ns;
+  return new_timer_interval_ns;
 }
 
 /*
@@ -206,8 +261,9 @@ void BPF_STRUCT_OPS(rorke_running, struct task_struct* p) {
 
   struct cpu_ctx* cctx;
   cctx = try_lookup_cpu_ctx(cpu);
-  if (cctx) {
-    memset(&cctx->data, 0, sizeof(struct sched_data));
+  if (!cctx) {
+    scx_bpf_error("Failed to lookup cpu_ctx for cpu - %d", cpu);
+	return;
   }
 
   int ret = bpf_timer_start(timer, cctx->timer_interval_ns, BPF_F_TIMER_CPU_PIN);
@@ -231,12 +287,14 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
   cctx = try_lookup_cpu_ctx(current_cpu);
   if (cctx) {
     cctx->preempted++;
-	// if (cctx->preempted % timer_interval_update_period == 0) {
-	// 	timer_interval_ns = compute_timer_interval_ns(&cctx->total_data);
-	// 	trace("compute_timer_interval_ns: instr=%llu cycles=%llu -> ps=%llu\n",
-    //          cctx->total_data.instr, cctx->total_data.cycles, timer_interval_ns);
-	// 	memset(&cctx->total_data, 0, sizeof(struct sched_data));
-	// }
+	cctx->preemptions_remaining--;
+	if (cctx->preemptions_remaining == 0) {
+		cctx->timer_interval_ns = compute_timer_interval_ns(cctx->timer_interval_ns, &cctx->data);
+		cctx->preemptions_remaining = switch_time_ns / cctx->timer_interval_ns;
+		info("timer_callback: updated timer interval to %llu ns - pCPU %d",
+			  cctx->timer_interval_ns, current_cpu);
+		memset(&cctx->data, 0, sizeof(struct sched_data));
+	}
   }
 
   scx_bpf_kick_cpu(current_cpu, SCX_KICK_PREEMPT);

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -218,6 +218,44 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
   return 0;
 }
 
+/*
+ * Perf event handler: attach perf fds opened by userspace to this BPF program.
+ * This handler extracts the sampled instruction count (sample_period) and
+ * accumulates it into a per-cpu counter map `instr_counts`.
+ */
+
+struct {
+  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+  __uint(max_entries, MAX_CPUS);
+  __type(key, u32);
+  __type(value, u64);
+} instr_counts SEC(".maps");
+
+SEC("perf_event")
+int on_perf_event(struct bpf_perf_event_data *ctx)
+{
+    u32 cpu = bpf_get_smp_processor_id();
+    u32 idx = cpu;
+
+    /* Try to read the sample period from the perf event ctx. For hardware
+     * instruction events this typically equals the number of instructions
+     * sampled at this instance (i.e. the period). Use CO-RE read to be
+     * compatible across kernel versions.
+     */
+    u64 instr = 0;
+    instr = BPF_CORE_READ(ctx, addr);
+
+    /* Lookup per-cpu counter and add the sampled instructions. We use the
+     * percpu array so updates are cheap and race-free for the local CPU.
+     */
+    u64 *cnt = bpf_map_lookup_percpu_elem(&instr_counts, &idx, cpu);
+    if (cnt) {
+        __sync_fetch_and_add(cnt, instr);
+    }
+	bpf_printk("CPU %d: Instructions executed: %llu", cpu, instr);
+
+    return 0;
+}
 s32 BPF_STRUCT_OPS_SLEEPABLE(rorke_init) {
   int ret;
   u32 i;

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -16,6 +16,7 @@
 #include <bpf/bpf_tracing.h>
 #include <errno.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "intf.h"
 
@@ -29,13 +30,46 @@ UEI_DEFINE(uei);
  */
 const volatile u32 nr_cpus = 1;
 const volatile u32 nr_vms = 1;
-const volatile u64 timer_interval_ns = 100000;
 const volatile u64 vms[MAX_VMS];
 const volatile u32 debug = 0;
 
 /* Scheduling statistics */
 volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
     nr_vm_dispatches, nr_running;
+
+/* Timer interval
+ * We store the timer interval in a 1-entry BPF array map so it can be
+ * safely updated (from userspace or from BPF) without torn reads/writes
+ * across CPUs. Reading code should lookup the element and fall back to
+ * a default if the map lookup fails.
+ */
+
+const u64 min_timer_interval_ns = 100000; // 100us
+const u64 max_timer_interval_ns = 1000000; // 1000us
+
+struct {
+  __uint(type, BPF_MAP_TYPE_ARRAY);
+  __uint(max_entries, 1);
+  __type(key, u32);
+  __type(value, u64);
+} config_map SEC(".maps");
+
+static u64 read_timer_interval_ns(void) {
+  u32 key = 0;
+  u64 *val = bpf_map_lookup_elem(&config_map, &key);
+  if (val)
+    return *val;
+  return min_timer_interval_ns;
+}
+
+static int write_timer_interval_ns(u64 new_val) {
+  u32 key = 0;
+  return bpf_map_update_elem(&config_map, &key, &new_val, BPF_ANY);
+}
+
+static u64 compute_timer_interval_ns(struct sched_data* data) {
+  return min_timer_interval_ns;
+}
 
 /*
  * Timer for preempting CPUs.
@@ -191,7 +225,14 @@ void BPF_STRUCT_OPS(rorke_running, struct task_struct* p) {
     return;
   }
 
-  int ret = bpf_timer_start(timer, timer_interval_ns, BPF_F_TIMER_CPU_PIN);
+  struct cpu_ctx* cctx;
+  cctx = try_lookup_cpu_ctx(cpu);
+  if (cctx) {
+    memset(&cctx->data, 0, sizeof(struct sched_data));
+  }
+
+  u64 tval = read_timer_interval_ns();
+  int ret = bpf_timer_start(timer, tval, BPF_F_TIMER_CPU_PIN);
   if (ret == -EINVAL) {
     scx_bpf_error("Failed to pin timer for cpu - %d", cpu);
     return;
@@ -213,6 +254,9 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
   if (cctx)
     cctx->preempted++;
 
+  u64 timer_interval_ns = compute_timer_interval_ns(&cctx->data);
+  write_timer_interval_ns(timer_interval_ns);
+
   scx_bpf_kick_cpu(current_cpu, SCX_KICK_PREEMPT);
   trace("timer_callback: preempted CPU %d", current_cpu);
   return 0;
@@ -221,33 +265,33 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
 SEC("perf_event")
 int count_instr(struct bpf_perf_event_data *ctx)
 {
-    struct cpu_ctx* cctx;
+  struct cpu_ctx* cctx;
 
-    u64 cnt = BPF_CORE_READ(ctx, addr);
+  u64 cnt = BPF_CORE_READ(ctx, addr);
 
-    s32 current_cpu = bpf_get_smp_processor_id();
-    cctx = try_lookup_cpu_ctx(current_cpu);
-    if (cctx) {
-        cctx->data.instr += cnt;
-    }
-    trace("count_instr: CPU %d counted %llu instructions\n", current_cpu, cnt);
-    return 0;
+  s32 current_cpu = bpf_get_smp_processor_id();
+  cctx = try_lookup_cpu_ctx(current_cpu);
+  if (cctx) {
+    cctx->data.instr += cnt;
+  }
+  trace("count_instr: CPU %d counted %llu instructions\n", current_cpu, cnt);
+  return 0;
 }
 
 SEC("perf_event")
 int count_cycles(struct bpf_perf_event_data *ctx)
 {
-    struct cpu_ctx* cctx;
+  struct cpu_ctx* cctx;
 
-    u64 cnt = BPF_CORE_READ(ctx, addr);
+  u64 cnt = BPF_CORE_READ(ctx, addr);
 
-    s32 current_cpu = bpf_get_smp_processor_id();
-    cctx = try_lookup_cpu_ctx(current_cpu);
-    if (cctx) {
-        cctx->data.cycles += cnt;
-    }
-    trace("count_cycles: CPU %d counted %llu cycles\n", current_cpu, cnt);
-    return 0;
+  s32 current_cpu = bpf_get_smp_processor_id();
+  cctx = try_lookup_cpu_ctx(current_cpu);
+  if (cctx) {
+    cctx->data.cycles += cnt;
+  }
+  trace("count_cycles: CPU %d counted %llu cycles\n", current_cpu, cnt);
+  return 0;
 }
 
 s32 BPF_STRUCT_OPS_SLEEPABLE(rorke_init) {
@@ -262,6 +306,8 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rorke_init) {
     }
     info("rorke_init: created dsq for VM-%d", vms[i]);
   }
+
+  write_timer_interval_ns(min_timer_interval_ns);
 
   struct bpf_timer* timer;
   bpf_for(i, 0, nr_cpus) {

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -29,6 +29,7 @@ UEI_DEFINE(uei);
  * Here we assign values just to pass the verifier.
  */
 const volatile u32 nr_cpus = 1;
+const volatile u32 nr_vcpus = 1;
 const volatile u32 nr_vms = 1;
 const volatile u64 vms[MAX_VMS];
 const volatile u32 debug = 0;
@@ -37,54 +38,16 @@ const volatile u32 debug = 0;
 volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
     nr_vm_dispatches, nr_running;
 
-/* Timer interval
- * We store the timer interval in a 1-entry BPF array map so it can be
- * safely updated (from userspace or from BPF) without torn reads/writes
- * across CPUs. Reading code should lookup the element and fall back to
- * a default if the map lookup fails.
- */
-
 const u64 min_timer_interval_ns = 100000; // 100us
-const u64 max_timer_interval_ns = 1000000; // 1000us
-const u64 timer_interval_update_period = 10; // update timer interval every this many preemptions
-volatile u64 timer_interval_ns = min_timer_interval_ns;
+const u64 max_timer_interval_ns = 1000000; // 1ms
+const u64 switch_time_ns = 5000000000; // 5s
+const u64 llc_miss_latency_ns = 2000; // 2us
 
 /*
  * Compute timer interval based on IPC.
- * For now, just linearly interpolate between points
- * (ipc=2.0, ps=100us) and (ipc=2.55, ps=1000us).
  */
 static u64 compute_timer_interval_ns(struct sched_data* data) {
-  // Avoid division by zero
-  if (data->cycles == 0)
-    return min_timer_interval_ns;
-
-  // Calculate IPC (instructions per cycle)
-  u64 ipc_fixed = (data->instr << 16) / data->cycles; // Q16.16 fixed point
-  
-  // IPC thresholds in Q16.16 (2.0 and 2.55)
-  const u64 min_ipc = 2ULL << 16;        // 2.0
-  const u64 max_ipc = (255ULL << 16)/100;  // 2.55
-
-  // If IPC <= 2.0, use min interval
-  if (ipc_fixed <= min_ipc)
-    return min_timer_interval_ns;
-  
-  // If IPC >= 2.55, use max interval
-  if (ipc_fixed >= max_ipc)
-    return max_timer_interval_ns;
-
-  // Linear interpolation between min_timer_interval_ns and max_timer_interval_ns
-  // as IPC goes from 2.0 to 2.55
-  u64 ipc_range = max_ipc - min_ipc;
-  u64 interval_range = max_timer_interval_ns - min_timer_interval_ns;
-  u64 ipc_offset = ipc_fixed - min_ipc;
-
-  // Calculate interpolated value: min + (offset/range) * interval_range
-  u64 interval = min_timer_interval_ns + 
-    ((ipc_offset * interval_range) / ipc_range);
-
-  return interval;
+  return 0;
 }
 
 /*
@@ -114,11 +77,6 @@ struct {
 struct cpu_ctx* try_lookup_cpu_ctx(s32 cpu) {
   const u32 idx = 0;
   return bpf_map_lookup_percpu_elem(&cpu_ctx_stor, &idx, cpu);
-}
-
-static void merge_sched_data(struct sched_data* dest, struct sched_data* src) {
-  dest->instr += src->instr;
-  dest->cycles += src->cycles;
 }
 
 /*
@@ -249,10 +207,10 @@ void BPF_STRUCT_OPS(rorke_running, struct task_struct* p) {
   struct cpu_ctx* cctx;
   cctx = try_lookup_cpu_ctx(cpu);
   if (cctx) {
-    memset(&cctx->cur_data, 0, sizeof(struct sched_data));
+    memset(&cctx->data, 0, sizeof(struct sched_data));
   }
 
-  int ret = bpf_timer_start(timer, timer_interval_ns, BPF_F_TIMER_CPU_PIN);
+  int ret = bpf_timer_start(timer, cctx->timer_interval_ns, BPF_F_TIMER_CPU_PIN);
   if (ret == -EINVAL) {
     scx_bpf_error("Failed to pin timer for cpu - %d", cpu);
     return;
@@ -273,13 +231,12 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
   cctx = try_lookup_cpu_ctx(current_cpu);
   if (cctx) {
     cctx->preempted++;
-	merge_sched_data(&cctx->total_data, &cctx->cur_data);
-	if (cctx->preempted % timer_interval_update_period == 0) {
-		timer_interval_ns = compute_timer_interval_ns(&cctx->total_data);
-		trace("compute_timer_interval_ns: instr=%llu cycles=%llu -> ps=%llu\n",
-             cctx->total_data.instr, cctx->total_data.cycles, timer_interval_ns);
-		memset(&cctx->total_data, 0, sizeof(struct sched_data));
-	}
+	// if (cctx->preempted % timer_interval_update_period == 0) {
+	// 	timer_interval_ns = compute_timer_interval_ns(&cctx->total_data);
+	// 	trace("compute_timer_interval_ns: instr=%llu cycles=%llu -> ps=%llu\n",
+    //          cctx->total_data.instr, cctx->total_data.cycles, timer_interval_ns);
+	// 	memset(&cctx->total_data, 0, sizeof(struct sched_data));
+	// }
   }
 
   scx_bpf_kick_cpu(current_cpu, SCX_KICK_PREEMPT);
@@ -288,7 +245,7 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
 }
 
 SEC("perf_event")
-int count_instr(struct bpf_perf_event_data *ctx)
+int count_llc_misses(struct bpf_perf_event_data *ctx)
 {
   struct cpu_ctx* cctx;
 
@@ -297,21 +254,7 @@ int count_instr(struct bpf_perf_event_data *ctx)
   s32 current_cpu = bpf_get_smp_processor_id();
   cctx = try_lookup_cpu_ctx(current_cpu);
   if (cctx)
-    cctx->cur_data.instr += cnt;
-  return 0;
-}
-
-SEC("perf_event")
-int count_cycles(struct bpf_perf_event_data *ctx)
-{
-  struct cpu_ctx* cctx;
-
-  u64 cnt = BPF_CORE_READ(ctx, addr);
-
-  s32 current_cpu = bpf_get_smp_processor_id();
-  cctx = try_lookup_cpu_ctx(current_cpu);
-  if (cctx)
-    cctx->cur_data.cycles += cnt;
+    cctx->data.llc_misses += cnt;
   return 0;
 }
 
@@ -338,6 +281,14 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rorke_init) {
     bpf_timer_init(timer, &timers, CLOCK_MONOTONIC);
     bpf_timer_set_callback(timer, timer_callback);
     info("rorke_init: initialized timer for cpu - %d\n", i);
+	struct cpu_ctx* cctx;
+	cctx = try_lookup_cpu_ctx(i);
+	if (!cctx) {
+	  scx_bpf_error("rorke_init: failed to lookup cpu_ctx for cpu - %d\n", i);
+	  return -ESRCH;
+	}
+	cctx->timer_interval_ns = min_timer_interval_ns;
+	cctx->preemptions_remaining = switch_time_ns / min_timer_interval_ns;
   }
   return ret;
 }

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -46,6 +46,7 @@ volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
 
 const u64 min_timer_interval_ns = 100000; // 100us
 const u64 max_timer_interval_ns = 1000000; // 1000us
+const u64 timer_interval_update_period = 10; // every 10 preemptions
 volatile u64 timer_interval_ns = min_timer_interval_ns;
 
 static u64 compute_timer_interval_ns(struct sched_data* data) {
@@ -81,6 +82,11 @@ struct {
 struct cpu_ctx* try_lookup_cpu_ctx(s32 cpu) {
   const u32 idx = 0;
   return bpf_map_lookup_percpu_elem(&cpu_ctx_stor, &idx, cpu);
+}
+
+static void merge_sched_data(struct sched_data* dest, struct sched_data* src) {
+  dest->instr += src->instr;
+  dest->cycles += src->cycles;
 }
 
 /*
@@ -211,7 +217,7 @@ void BPF_STRUCT_OPS(rorke_running, struct task_struct* p) {
   struct cpu_ctx* cctx;
   cctx = try_lookup_cpu_ctx(cpu);
   if (cctx) {
-    memset(&cctx->data, 0, sizeof(struct sched_data));
+    memset(&cctx->cur_data, 0, sizeof(struct sched_data));
   }
 
   int ret = bpf_timer_start(timer, timer_interval_ns, BPF_F_TIMER_CPU_PIN);
@@ -235,7 +241,11 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
   cctx = try_lookup_cpu_ctx(current_cpu);
   if (cctx) {
     cctx->preempted++;
-    timer_interval_ns = compute_timer_interval_ns(&cctx->data);
+	merge_sched_data(&cctx->total_data, &cctx->cur_data);
+	if (cctx->preempted % timer_interval_update_period == 0) {
+		timer_interval_ns = compute_timer_interval_ns(&cctx->total_data);
+		memset(&cctx->total_data, 0, sizeof(struct sched_data));
+	}
   }
 
   scx_bpf_kick_cpu(current_cpu, SCX_KICK_PREEMPT);
@@ -252,9 +262,8 @@ int count_instr(struct bpf_perf_event_data *ctx)
 
   s32 current_cpu = bpf_get_smp_processor_id();
   cctx = try_lookup_cpu_ctx(current_cpu);
-  if (cctx) {
-    cctx->data.instr += cnt;
-  }
+  if (cctx)
+    cctx->cur_data.instr += cnt;
   return 0;
 }
 
@@ -267,9 +276,8 @@ int count_cycles(struct bpf_perf_event_data *ctx)
 
   s32 current_cpu = bpf_get_smp_processor_id();
   cctx = try_lookup_cpu_ctx(current_cpu);
-  if (cctx) {
-    cctx->data.cycles += cnt;
-  }
+  if (cctx)
+    cctx->cur_data.cycles += cnt;
   return 0;
 }
 

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -40,8 +40,9 @@ volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
 
 const u64 min_timer_interval_ns = 100000; // 100us
 const u64 max_timer_interval_ns = 1000000; // 1ms
-const u64 switch_time_ns = 10000000000; // 10s
+const u64 switch_time_ns = 3000000000; // 3s
 const u64 llc_miss_latency_ns = 4000; // 4us
+const u64 max_interval_change_ns = 200000; // 200us
 
 /*
  * Compute timer interval based on IPC.
@@ -61,6 +62,16 @@ static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_dat
    * return new_timer_interval_ns
    */
 
+  info("compute_timer_interval_ns: old_timer_interval_ns=%llu, llc_misses=%llu",
+	   old_timer_interval_ns, data->llc_misses);
+
+  if (data->llc_misses == 0) {
+    // Anomalous case: no LLC misses recorded, return old interval
+    info("compute_timer_interval_ns: llc_misses=0, returning old_timer_interval_ns=%llu",
+     old_timer_interval_ns);
+    return old_timer_interval_ns;
+  }
+
   // Use Q6 fixed-point (scale = 1,000,000)
   static const u64 SCALE = 1000000;
   static const u64 EPSILON_FP = 200000; // 0.2 in fixed-point
@@ -74,34 +85,47 @@ static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_dat
   if (nr_cpus > 0)
     oversub_fp = ((u64)nr_vcpus) * SCALE / nr_cpus;
 
+  u64 new_timer_interval_ns;
   // If rho >= 1.0 (i.e., rho_fp >= SCALE)
-  if (rho_fp >= SCALE)
-    return max_timer_interval_ns;
+  if (rho_fp >= SCALE) {
+    new_timer_interval_ns = max_timer_interval_ns;
+    info("compute_timer_interval_ns: rho_fp >= SCALE, returning max_timer_interval_ns=%llu",
+     max_timer_interval_ns);
+  } else {
+    // chain_latency = (oversubscription_ratio - 1) * old_timer_interval_ns * rho / (1 - rho)
+    // All in fixed-point
+    s64 oversub_minus1_fp = (s64)oversub_fp - (s64)SCALE;
 
-  // chain_latency = (oversubscription_ratio - 1) * old_timer_interval_ns * rho / (1 - rho)
-  // All in fixed-point
-  s64 oversub_minus1_fp = (s64)oversub_fp - (s64)SCALE;
+    // numerator: (oversub_minus1_fp * old_timer_interval_ns * rho_fp)
+    // denominator: (SCALE - rho_fp)
+    u64 denominator = SCALE - rho_fp;
+    u64 chain_latency = 0;
+    if (denominator > 0) {
+      u64 numerator = (u64)(oversub_minus1_fp) * old_timer_interval_ns * rho_fp;
+      chain_latency = numerator / denominator;
+    }
 
-  // numerator: (oversub_minus1_fp * old_timer_interval_ns * rho_fp)
-  // denominator: (SCALE - rho_fp)
-  u64 denominator = SCALE - rho_fp;
-  u64 chain_latency = 0;
-  if (denominator > 0) {
-    u64 numerator = (u64)(oversub_minus1_fp) * old_timer_interval_ns * rho_fp;
-    chain_latency = numerator / denominator;
+    // new_timer_interval_ns = chain_latency * 1.2 (fixed-point: 1.2 = 1200000)
+    new_timer_interval_ns = (chain_latency * (SCALE + EPSILON_FP)) / SCALE / SCALE;
+
+    info("compute_timer_interval_ns: llc_misses=%llu, rho_fp=%llu, "
+        "oversub_fp=%llu, chain_latency=%llu, new_timer_interval_ns=%llu",
+      llc_misses, rho_fp, oversub_fp, chain_latency, new_timer_interval_ns);
   }
 
-  // new_timer_interval_ns = chain_latency * 1.2 (fixed-point: 1.2 = 1200000)
-  u64 new_timer_interval_ns = (chain_latency * (SCALE + EPSILON_FP)) / SCALE / SCALE;
-
-  info("compute_timer_interval_ns: llc_misses=%llu, rho_fp=%llu, "
-		   "oversub_fp=%llu, chain_latency=%llu, new_timer_interval_ns=%llu",
-	   llc_misses, rho_fp, oversub_fp, chain_latency, new_timer_interval_ns);
-
+  info("new_timer_interval_ns: %llu, old_timer_interval_ns=%llu",
+     new_timer_interval_ns, old_timer_interval_ns);
   if (new_timer_interval_ns < min_timer_interval_ns)
     new_timer_interval_ns = min_timer_interval_ns;
   if (new_timer_interval_ns > max_timer_interval_ns)
     new_timer_interval_ns = max_timer_interval_ns;
+  if (new_timer_interval_ns > old_timer_interval_ns + max_interval_change_ns) {
+    new_timer_interval_ns = old_timer_interval_ns + max_interval_change_ns;
+  }
+  if (new_timer_interval_ns + max_interval_change_ns < old_timer_interval_ns) {
+	  new_timer_interval_ns = old_timer_interval_ns - max_interval_change_ns;
+  }
+
   return new_timer_interval_ns;
 }
 
@@ -287,14 +311,14 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
   cctx = try_lookup_cpu_ctx(current_cpu);
   if (cctx) {
     cctx->preempted++;
-	cctx->preemptions_remaining--;
-	if (cctx->preemptions_remaining == 0) {
-		cctx->timer_interval_ns = compute_timer_interval_ns(cctx->timer_interval_ns, &cctx->data);
-		cctx->preemptions_remaining = switch_time_ns / cctx->timer_interval_ns;
-		info("timer_callback: updated timer interval to %llu ns - pCPU %d",
-			  cctx->timer_interval_ns, current_cpu);
-		memset(&cctx->data, 0, sizeof(struct sched_data));
-	}
+    cctx->preemptions_remaining--;
+    if (cctx->preemptions_remaining == 0) {
+      cctx->timer_interval_ns = compute_timer_interval_ns(cctx->timer_interval_ns, &cctx->data);
+      cctx->preemptions_remaining = switch_time_ns / cctx->timer_interval_ns;
+      info("timer_callback: updated timer interval to %llu ns - pCPU %d",
+          cctx->timer_interval_ns, current_cpu);
+      memset(&cctx->data, 0, sizeof(struct sched_data));
+    }
   }
 
   scx_bpf_kick_cpu(current_cpu, SCX_KICK_PREEMPT);
@@ -308,8 +332,8 @@ int count_llc_misses(struct bpf_perf_event_data *ctx)
   struct cpu_ctx* cctx;
 
   u64 cnt = BPF_CORE_READ(ctx, addr);
-  info("count_llc_misses: CPU %d, llc_misses=%llu",
-	   bpf_get_smp_processor_id(), cnt);
+//   info("count_llc_misses: CPU %d, llc_misses=%llu, sample_period=%llu",
+// 	   bpf_get_smp_processor_id(), cnt, ctx->sample_period);
 
   s32 current_cpu = bpf_get_smp_processor_id();
   cctx = try_lookup_cpu_ctx(current_cpu);

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -40,16 +40,54 @@ volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
 
 const u64 min_timer_interval_ns = 100000; // 100us
 const u64 max_timer_interval_ns = 1000000; // 1ms
-const u64 switch_time_ns = 3000000000; // 3s
-const u64 llc_miss_latency_ns = 4000; // 4us
-const u64 max_interval_change_ns = 200000; // 200us
+const u64 switch_time_ns = 5000000000; // 5s
+const u64 llc_miss_latency_ns = 200; // 200ns
 
 /*
- * Compute timer interval based on IPC.
+ * Data window helpers.
+ */
+static void data_window_init_idx(struct data_window* dw, u32 idx) {
+  if (idx < WINDOW_SIZE) {
+    dw->window[idx].llc_misses = 0;
+    dw->window[idx].interval_ns = switch_time_ns;
+  }
+}
+
+static void data_window_init(struct data_window* dw) {
+  memset(dw, 0, sizeof(*dw));
+  dw->current = 0;
+  data_window_init_idx(dw, 0);
+}
+
+static void data_window_advance(struct data_window* dw) {
+  u32 idx = dw->current + 1;
+  if (idx >= WINDOW_SIZE)
+    idx = 0;
+  dw->current = idx;
+  data_window_init_idx(dw, idx);
+}
+
+static struct sched_data* data_window_current(struct data_window* dw) {
+  u32 idx = dw->current;
+  return idx < WINDOW_SIZE ? &dw->window[dw->current] : NULL;
+}
+
+static void data_window_accumulate(struct data_window* dw,
+                                   struct sched_data* acc) {
+  int i;
+  memset(acc, 0, sizeof(*acc));
+  for (i = 0; i < WINDOW_SIZE; i++) {
+    acc->llc_misses += dw->window[i].llc_misses;
+    acc->interval_ns += dw->window[i].interval_ns;
+  }
+}
+
+/*
+ * Compute timer interval.
  */
 static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_data* data) {
   /*
-   * rho = llc_misses * llc_miss_latency / switch_time
+   * rho = llc_misses * llc_miss_latency / interval
    * oversubcription_ratio = nr_vcpus / nr_cpus
    * if rho >= 1.0:
    *     return max_timer_interval_ns
@@ -62,12 +100,12 @@ static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_dat
    * return new_timer_interval_ns
    */
 
-  info("compute_timer_interval_ns: old_timer_interval_ns=%llu, llc_misses=%llu",
+  info("compute interval: old interval=%llu, llc_misses=%llu",
 	   old_timer_interval_ns, data->llc_misses);
 
   if (data->llc_misses == 0) {
     // Anomalous case: no LLC misses recorded, return old interval
-    info("compute_timer_interval_ns: llc_misses=0, returning old_timer_interval_ns=%llu",
+    info("compute interval: llc_misses=0, returning old interval=%llu",
      old_timer_interval_ns);
     return old_timer_interval_ns;
   }
@@ -76,9 +114,8 @@ static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_dat
   static const u64 SCALE = 1000000;
   static const u64 EPSILON_FP = 200000; // 0.2 in fixed-point
   u64 llc_misses = data->llc_misses;
-  u64 rho_fp = 0;
-  if (switch_time_ns > 0)
-    rho_fp = (llc_misses * llc_miss_latency_ns * SCALE) / switch_time_ns;
+  u64 interval_ns = data->interval_ns;
+  u64 rho_fp = (llc_misses * llc_miss_latency_ns * SCALE) / interval_ns;
 
   // oversubscription_ratio = nr_vcpus / nr_cpus (fixed-point)
   u64 oversub_fp = 0;
@@ -89,7 +126,7 @@ static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_dat
   // If rho >= 1.0 (i.e., rho_fp >= SCALE)
   if (rho_fp >= SCALE) {
     new_timer_interval_ns = max_timer_interval_ns;
-    info("compute_timer_interval_ns: rho_fp >= SCALE, returning max_timer_interval_ns=%llu",
+    info("compute_timer_interval_ns: rho_fp >= SCALE, returning max interval=%llu",
      max_timer_interval_ns);
   } else {
     // chain_latency = (oversubscription_ratio - 1) * old_timer_interval_ns * rho / (1 - rho)
@@ -108,9 +145,9 @@ static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_dat
     // new_timer_interval_ns = chain_latency * 1.2 (fixed-point: 1.2 = 1200000)
     new_timer_interval_ns = (chain_latency * (SCALE + EPSILON_FP)) / SCALE / SCALE;
 
-    info("compute_timer_interval_ns: llc_misses=%llu, rho_fp=%llu, "
+    info("compute interval: llc_misses=%llu, sample_interval=%llu, rho_fp=%llu, "
         "oversub_fp=%llu, chain_latency=%llu, new_timer_interval_ns=%llu",
-      llc_misses, rho_fp, oversub_fp, chain_latency, new_timer_interval_ns);
+      llc_misses, interval_ns, rho_fp, oversub_fp, chain_latency, new_timer_interval_ns);
   }
 
   info("new_timer_interval_ns: %llu, old_timer_interval_ns=%llu",
@@ -119,12 +156,6 @@ static u64 compute_timer_interval_ns(u64 old_timer_interval_ns, struct sched_dat
     new_timer_interval_ns = min_timer_interval_ns;
   if (new_timer_interval_ns > max_timer_interval_ns)
     new_timer_interval_ns = max_timer_interval_ns;
-  if (new_timer_interval_ns > old_timer_interval_ns + max_interval_change_ns) {
-    new_timer_interval_ns = old_timer_interval_ns + max_interval_change_ns;
-  }
-  if (new_timer_interval_ns + max_interval_change_ns < old_timer_interval_ns) {
-	  new_timer_interval_ns = old_timer_interval_ns - max_interval_change_ns;
-  }
 
   return new_timer_interval_ns;
 }
@@ -313,11 +344,13 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
     cctx->preempted++;
     cctx->preemptions_remaining--;
     if (cctx->preemptions_remaining == 0) {
-      cctx->timer_interval_ns = compute_timer_interval_ns(cctx->timer_interval_ns, &cctx->data);
-      cctx->preemptions_remaining = switch_time_ns / cctx->timer_interval_ns;
+      struct sched_data acc;
+      data_window_accumulate(&cctx->data, &acc);
+      cctx->timer_interval_ns = compute_timer_interval_ns(cctx->timer_interval_ns, &acc);
       info("timer_callback: updated timer interval to %llu ns - pCPU %d",
           cctx->timer_interval_ns, current_cpu);
-      memset(&cctx->data, 0, sizeof(struct sched_data));
+      cctx->preemptions_remaining = switch_time_ns / cctx->timer_interval_ns;
+      data_window_advance(&cctx->data);
     }
   }
 
@@ -337,8 +370,13 @@ int count_llc_misses(struct bpf_perf_event_data *ctx)
 
   s32 current_cpu = bpf_get_smp_processor_id();
   cctx = try_lookup_cpu_ctx(current_cpu);
-  if (cctx)
-    cctx->data.llc_misses += cnt;
+  if (cctx) {
+    struct sched_data* cur_data = data_window_current(&cctx->data);
+
+    if (cur_data) {
+      cur_data->llc_misses += cnt;
+    }
+  }
   return 0;
 }
 
@@ -365,14 +403,15 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rorke_init) {
     bpf_timer_init(timer, &timers, CLOCK_MONOTONIC);
     bpf_timer_set_callback(timer, timer_callback);
     info("rorke_init: initialized timer for cpu - %d\n", i);
-	struct cpu_ctx* cctx;
-	cctx = try_lookup_cpu_ctx(i);
-	if (!cctx) {
-	  scx_bpf_error("rorke_init: failed to lookup cpu_ctx for cpu - %d\n", i);
-	  return -ESRCH;
-	}
-	cctx->timer_interval_ns = min_timer_interval_ns;
-	cctx->preemptions_remaining = switch_time_ns / min_timer_interval_ns;
+    struct cpu_ctx* cctx;
+    cctx = try_lookup_cpu_ctx(i);
+    if (!cctx) {
+      scx_bpf_error("rorke_init: failed to lookup cpu_ctx for cpu - %d\n", i);
+      return -ESRCH;
+    }
+    cctx->timer_interval_ns = min_timer_interval_ns;
+    cctx->preemptions_remaining = switch_time_ns / min_timer_interval_ns;
+    data_window_init(&cctx->data);
   }
   return ret;
 }

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -40,7 +40,7 @@ volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
 
 const u64 min_timer_interval_ns = 100000; // 100us
 const u64 max_timer_interval_ns = 1000000; // 1ms
-const u64 switch_time_ns = 5000000000; // 5s
+const u64 switch_time_ns = 10000000000; // 10s
 const u64 llc_miss_latency_ns = 4000; // 4us
 
 /*
@@ -308,6 +308,8 @@ int count_llc_misses(struct bpf_perf_event_data *ctx)
   struct cpu_ctx* cctx;
 
   u64 cnt = BPF_CORE_READ(ctx, addr);
+  info("count_llc_misses: CPU %d, llc_misses=%llu",
+	   bpf_get_smp_processor_id(), cnt);
 
   s32 current_cpu = bpf_get_smp_processor_id();
   cctx = try_lookup_cpu_ctx(current_cpu);

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -218,44 +218,38 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
   return 0;
 }
 
-/*
- * Perf event handler: attach perf fds opened by userspace to this BPF program.
- * This handler extracts the sampled instruction count (sample_period) and
- * accumulates it into a per-cpu counter map `instr_counts`.
- */
-
-struct {
-  __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
-  __uint(max_entries, MAX_CPUS);
-  __type(key, u32);
-  __type(value, u64);
-} instr_counts SEC(".maps");
-
 SEC("perf_event")
-int on_perf_event(struct bpf_perf_event_data *ctx)
+int count_instr(struct bpf_perf_event_data *ctx)
 {
-    u32 cpu = bpf_get_smp_processor_id();
-    u32 idx = cpu;
+    struct cpu_ctx* cctx;
 
-    /* Try to read the sample period from the perf event ctx. For hardware
-     * instruction events this typically equals the number of instructions
-     * sampled at this instance (i.e. the period). Use CO-RE read to be
-     * compatible across kernel versions.
-     */
-    u64 instr = 0;
-    instr = BPF_CORE_READ(ctx, addr);
+    u64 cnt = BPF_CORE_READ(ctx, addr);
 
-    /* Lookup per-cpu counter and add the sampled instructions. We use the
-     * percpu array so updates are cheap and race-free for the local CPU.
-     */
-    u64 *cnt = bpf_map_lookup_percpu_elem(&instr_counts, &idx, cpu);
-    if (cnt) {
-        __sync_fetch_and_add(cnt, instr);
+    s32 current_cpu = bpf_get_smp_processor_id();
+    cctx = try_lookup_cpu_ctx(current_cpu);
+    if (cctx) {
+        cctx->data.instr += cnt;
     }
-	bpf_printk("CPU %d: Instructions executed: %llu", cpu, instr);
-
+    trace("count_instr: CPU %d counted %llu instructions\n", current_cpu, cnt);
     return 0;
 }
+
+SEC("perf_event")
+int count_cycles(struct bpf_perf_event_data *ctx)
+{
+    struct cpu_ctx* cctx;
+
+    u64 cnt = BPF_CORE_READ(ctx, addr);
+
+    s32 current_cpu = bpf_get_smp_processor_id();
+    cctx = try_lookup_cpu_ctx(current_cpu);
+    if (cctx) {
+        cctx->data.cycles += cnt;
+    }
+    trace("count_cycles: CPU %d counted %llu cycles\n", current_cpu, cnt);
+    return 0;
+}
+
 s32 BPF_STRUCT_OPS_SLEEPABLE(rorke_init) {
   int ret;
   u32 i;

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -46,13 +46,45 @@ volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
 
 const u64 min_timer_interval_ns = 100000; // 100us
 const u64 max_timer_interval_ns = 1000000; // 1000us
-const u64 timer_interval_update_period = 10; // every 10 preemptions
+const u64 timer_interval_update_period = 10; // update timer interval every this many preemptions
 volatile u64 timer_interval_ns = min_timer_interval_ns;
 
+/*
+ * Compute timer interval based on IPC.
+ * For now, just linearly interpolate between points
+ * (ipc=2.0, ps=100us) and (ipc=2.55, ps=1000us).
+ */
 static u64 compute_timer_interval_ns(struct sched_data* data) {
-  trace("compute_timer_interval_ns: instr=%llu cycles=%llu\n",
-             data->instr, data->cycles);
-  return min_timer_interval_ns;
+  // Avoid division by zero
+  if (data->cycles == 0)
+    return min_timer_interval_ns;
+
+  // Calculate IPC (instructions per cycle)
+  u64 ipc_fixed = (data->instr << 16) / data->cycles; // Q16.16 fixed point
+  
+  // IPC thresholds in Q16.16 (2.0 and 2.55)
+  const u64 min_ipc = 2ULL << 16;        // 2.0
+  const u64 max_ipc = (255ULL << 16)/100;  // 2.55
+
+  // If IPC <= 2.0, use min interval
+  if (ipc_fixed <= min_ipc)
+    return min_timer_interval_ns;
+  
+  // If IPC >= 2.55, use max interval
+  if (ipc_fixed >= max_ipc)
+    return max_timer_interval_ns;
+
+  // Linear interpolation between min_timer_interval_ns and max_timer_interval_ns
+  // as IPC goes from 2.0 to 2.55
+  u64 ipc_range = max_ipc - min_ipc;
+  u64 interval_range = max_timer_interval_ns - min_timer_interval_ns;
+  u64 ipc_offset = ipc_fixed - min_ipc;
+
+  // Calculate interpolated value: min + (offset/range) * interval_range
+  u64 interval = min_timer_interval_ns + 
+    ((ipc_offset * interval_range) / ipc_range);
+
+  return interval;
 }
 
 /*
@@ -244,6 +276,8 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
 	merge_sched_data(&cctx->total_data, &cctx->cur_data);
 	if (cctx->preempted % timer_interval_update_period == 0) {
 		timer_interval_ns = compute_timer_interval_ns(&cctx->total_data);
+		trace("compute_timer_interval_ns: instr=%llu cycles=%llu -> ps=%llu\n",
+             cctx->total_data.instr, cctx->total_data.cycles, timer_interval_ns);
 		memset(&cctx->total_data, 0, sizeof(struct sched_data));
 	}
   }

--- a/scheds/rust/scx_rorke/src/bpf/main.bpf.c
+++ b/scheds/rust/scx_rorke/src/bpf/main.bpf.c
@@ -46,28 +46,11 @@ volatile u64 nr_direct_to_idle_dispatches, nr_kthread_dispatches,
 
 const u64 min_timer_interval_ns = 100000; // 100us
 const u64 max_timer_interval_ns = 1000000; // 1000us
-
-struct {
-  __uint(type, BPF_MAP_TYPE_ARRAY);
-  __uint(max_entries, 1);
-  __type(key, u32);
-  __type(value, u64);
-} config_map SEC(".maps");
-
-static u64 read_timer_interval_ns(void) {
-  u32 key = 0;
-  u64 *val = bpf_map_lookup_elem(&config_map, &key);
-  if (val)
-    return *val;
-  return min_timer_interval_ns;
-}
-
-static int write_timer_interval_ns(u64 new_val) {
-  u32 key = 0;
-  return bpf_map_update_elem(&config_map, &key, &new_val, BPF_ANY);
-}
+volatile u64 timer_interval_ns = min_timer_interval_ns;
 
 static u64 compute_timer_interval_ns(struct sched_data* data) {
+  trace("compute_timer_interval_ns: instr=%llu cycles=%llu\n",
+             data->instr, data->cycles);
   return min_timer_interval_ns;
 }
 
@@ -231,8 +214,7 @@ void BPF_STRUCT_OPS(rorke_running, struct task_struct* p) {
     memset(&cctx->data, 0, sizeof(struct sched_data));
   }
 
-  u64 tval = read_timer_interval_ns();
-  int ret = bpf_timer_start(timer, tval, BPF_F_TIMER_CPU_PIN);
+  int ret = bpf_timer_start(timer, timer_interval_ns, BPF_F_TIMER_CPU_PIN);
   if (ret == -EINVAL) {
     scx_bpf_error("Failed to pin timer for cpu - %d", cpu);
     return;
@@ -251,11 +233,10 @@ static int timer_callback(void* map, int* key, struct bpf_timer* timer) {
 
   s32 current_cpu = bpf_get_smp_processor_id();
   cctx = try_lookup_cpu_ctx(current_cpu);
-  if (cctx)
+  if (cctx) {
     cctx->preempted++;
-
-  u64 timer_interval_ns = compute_timer_interval_ns(&cctx->data);
-  write_timer_interval_ns(timer_interval_ns);
+    timer_interval_ns = compute_timer_interval_ns(&cctx->data);
+  }
 
   scx_bpf_kick_cpu(current_cpu, SCX_KICK_PREEMPT);
   trace("timer_callback: preempted CPU %d", current_cpu);
@@ -274,7 +255,6 @@ int count_instr(struct bpf_perf_event_data *ctx)
   if (cctx) {
     cctx->data.instr += cnt;
   }
-  trace("count_instr: CPU %d counted %llu instructions\n", current_cpu, cnt);
   return 0;
 }
 
@@ -290,7 +270,6 @@ int count_cycles(struct bpf_perf_event_data *ctx)
   if (cctx) {
     cctx->data.cycles += cnt;
   }
-  trace("count_cycles: CPU %d counted %llu cycles\n", current_cpu, cnt);
   return 0;
 }
 
@@ -306,8 +285,6 @@ s32 BPF_STRUCT_OPS_SLEEPABLE(rorke_init) {
     }
     info("rorke_init: created dsq for VM-%d", vms[i]);
   }
-
-  write_timer_interval_ns(min_timer_interval_ns);
 
   struct bpf_timer* timer;
   bpf_for(i, 0, nr_cpus) {

--- a/scheds/rust/scx_rorke/src/config.rs
+++ b/scheds/rust/scx_rorke/src/config.rs
@@ -3,8 +3,8 @@ use serde_json::Result;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct VMConfig {
-	pub vm_name: String,
-	pub vm_id: u64,
+    pub vm_name: String,
+    pub vm_id: u64,
     pub vcpus: Vec<u64>,
 }
 
@@ -133,4 +133,3 @@ mod tests {
         assert_eq!(cpu_allocation, expected_allocation);
     }
 }
-

--- a/scheds/rust/scx_rorke/src/config.rs
+++ b/scheds/rust/scx_rorke/src/config.rs
@@ -3,7 +3,8 @@ use serde_json::Result;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct VMConfig {
-    pub vm_id: u64,
+	pub vm_name: String,
+	pub vm_id: u64,
     pub vcpus: Vec<u64>,
 }
 
@@ -48,10 +49,12 @@ mod tests {
         let config_json = r#"
         [
             {
+				"vm_name": "vm1",
                 "vm_id": 1,
                 "vcpus": [11,12]
             },
             {
+				"vm_name": "vm2",
                 "vm_id": 2,
                 "vcpus": [21,22,23,24]
             }
@@ -78,10 +81,12 @@ mod tests {
         let config_json = r#"
         [
             {
+				"vm_name": "vm1",
                 "vm_id": 1,
                 "vcpus": [11,12,13,14]
             },
             {
+				"vm_name": "vm2",
                 "vm_id": 2,
                 "vcpus": [21,22,23,24]
             }
@@ -107,6 +112,7 @@ mod tests {
         let config_json = r#"
         [
             {
+				"vm_name": "vm1",
                 "vm_id": 1,
                 "vcpus": [11,12,13,14]
             }
@@ -127,3 +133,4 @@ mod tests {
         assert_eq!(cpu_allocation, expected_allocation);
     }
 }
+

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -169,11 +169,23 @@ fn initialize_cpu_ctxs(skel: &BpfSkel, cpu_allocation: &Vec<u64>) -> Result<()> 
     Ok(())
 }
 
+struct SchedMetric {
+    name: String, // human-readable label
+    config: u64, // what to count, e.g. PERF_COUNT_HW_INSTRUCTIONS
+    sample_period: u64, // perf event is triggered every sample_period counts
+    prog_fd: i32, // fd of the BPF program to attach
+	link_fds: Vec<i32>, // fds of the perf event link, closed on drop
+}
+
+fn prog_fd<P: AsFd>(prog: &P) -> i32 {
+    prog.as_fd().as_raw_fd()
+}
+
 struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
     stats_server: StatsServer<(), Metrics>,
-    perf_links: Vec<i32>,
+    sched_metrics: Vec<SchedMetric>,
 }
 
 impl<'a> Scheduler<'a> {
@@ -219,47 +231,62 @@ impl<'a> Scheduler<'a> {
 
         let mut skel = scx_ops_load!(skel, rorke, uei)?;
 
-        let mut perf_links = Vec::<i32>::new();
+		// This needs to be initalized after skel is loaded to get valid prog fds
+		let mut sched_metrics: Vec<SchedMetric> = vec![
+			SchedMetric {
+				name: "instructions".to_string(),
+				config: sys::bindings::PERF_COUNT_HW_INSTRUCTIONS as u64,
+				sample_period: 1_000,
+				prog_fd: prog_fd(&skel.progs.count_instr),
+				link_fds: vec![],
+			},
+			SchedMetric {
+				name: "cycles".to_string(),
+				config: sys::bindings::PERF_COUNT_HW_CPU_CYCLES as u64,
+				sample_period: 1_000,
+				prog_fd: prog_fd(&skel.progs.count_cycles),
+				link_fds: vec![],
+			},
+		];
+
         for cpu in 0..opts.num_cpus {
-            let mut attrs = sys::bindings::perf_event_attr::default();
-            attrs.size = std::mem::size_of::<sys::bindings::perf_event_attr>() as u32;
-            attrs.type_ = sys::bindings::PERF_TYPE_HARDWARE;
-            attrs.set_disabled(1);
-            attrs.set_exclude_kernel(1);
-            attrs.set_exclude_hv(1);
-			attrs.__bindgen_anon_1.sample_period = 100; // perf event triggers every sample_period instructions
-			attrs.config = sys::bindings::PERF_COUNT_HW_INSTRUCTIONS as u64;
+			for metric in sched_metrics.iter_mut() {
+				let mut attrs = sys::bindings::perf_event_attr::default();
+				attrs.size = std::mem::size_of::<sys::bindings::perf_event_attr>() as u32;
+				attrs.type_ = sys::bindings::PERF_TYPE_HARDWARE;
+				attrs.set_disabled(1);
+				attrs.set_exclude_kernel(1);
+				attrs.set_exclude_hv(1);
+				attrs.config = metric.config;
+				attrs.__bindgen_anon_1.sample_period = metric.sample_period;
+				let perf_fd = unsafe {
+					sys::perf_event_open(&mut attrs, -1, cpu as i32, -1, 0)
+				};
+				if perf_fd < 0 {
+					return Err(anyhow!("Cannot open perf event for pcpu {:?} metric {:?}", cpu, metric.name));
+				}
+				// Create link between perf event and BPF program
+				let link_fd = unsafe {
+					libbpf_sys::bpf_link_create(
+						metric.prog_fd,
+						perf_fd,
+						libbpf_sys::BPF_PERF_EVENT as u32,
+						std::ptr::null(),
+					)
+				};
+				if link_fd < 0 {
+					return Err(anyhow!("Failed to create perf event link for CPU {} metric {:?}", cpu, metric.name));
+				}
+				// Enable the perf event
+				let enable_rc = unsafe {
+					libc::ioctl(perf_fd, 0x2400, 0)
+				};
+				if enable_rc != 0 {
+					return Err(anyhow!("Failed to enable perf event for CPU {} metric {:?}", cpu, metric.name));
+				}
 
-            let perf_fd = unsafe {
-                sys::perf_event_open(&mut attrs, -1, cpu as i32, -1, 0)
-            };
-            if perf_fd < 0 {
-                return Err(anyhow!("Cannot open perf instructions event for pcpu {:?}", cpu));
-            }
-			// Fd of the BPF program to attach
-            let prog_fd = skel.progs.on_perf_event.as_fd().as_raw_fd();
-            // Create link between perf event and BPF program
-            let link_fd = unsafe {
-                libbpf_sys::bpf_link_create(
-                    prog_fd,
-                    perf_fd,
-                    libbpf_sys::BPF_PERF_EVENT as u32,
-                    std::ptr::null(),
-                )
-            };
-            if link_fd < 0 {
-                return Err(anyhow!("Failed to create perf event link for CPU {}", cpu));
-            }
-
-			// Enable the perf event
-            let enable_rc = unsafe {
-                libc::ioctl(perf_fd, 0x2400, 0)
-            };
-            if enable_rc != 0 {
-                return Err(anyhow!("Failed to enable perf event for CPU {}", cpu));
-            }
-
-            perf_links.push(link_fd);
+				metric.link_fds.push(link_fd);
+			}
         }
 
         initialize_cpu_ctxs(&skel, &cpu_allocation)?;
@@ -327,7 +354,7 @@ impl<'a> Scheduler<'a> {
             skel,
             struct_ops,
             stats_server,
-            perf_links,
+			sched_metrics,
         })
     }
 
@@ -368,11 +395,13 @@ impl<'a> Drop for Scheduler<'a> {
         info!("Unregister {} scheduler", SCHEDULER_NAME);
         
         // Clean up perf links
-        for &link_fd in self.perf_links.iter() {
-            unsafe {
-                libc::close(link_fd);
-            }
-        }
+		for metric in self.sched_metrics.iter() {
+			for link_fd in metric.link_fds.iter() {
+				unsafe {
+					libc::close(*link_fd);
+				}
+			}
+		}
     }
 }
 

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -11,12 +11,12 @@ use stats::Metrics;
 use std::env;
 use std::fs;
 use std::mem::MaybeUninit;
+use std::os::fd::{AsFd, AsRawFd};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
-use std::os::fd::{AsFd, AsRawFd};
 
 use libc::{sched_param, sched_setscheduler};
 use std::process::Command;
@@ -170,12 +170,13 @@ fn initialize_cpu_ctxs(skel: &BpfSkel, cpu_allocation: &Vec<u64>) -> Result<()> 
 }
 
 struct SchedMetric {
-    name: String, // human-readable label
-	event_type: u32, // PERF_TYPE_HARDWARE, PERF_TYPE_RAW, etc.
-    config: u64, // what to count, e.g. PERF_COUNT_HW_INSTRUCTIONS
+    name: String,       // human-readable label
+    event_type: u32,    // PERF_TYPE_HARDWARE, PERF_TYPE_RAW, etc.
+    config: u64,        // what to count, e.g. PERF_COUNT_HW_INSTRUCTIONS
     sample_period: u64, // perf event is triggered every sample_period counts
-    prog_fd: i32, // fd of the BPF program to attach
-	link_fds: Vec<i32>, // fds of the perf event link, closed on drop
+    prog_fd: i32,       // fd of the BPF program to attach
+    perf_fds: Vec<i32>, // fds of the perf events, closed on drop
+    link_fds: Vec<i32>, // fds of the perf event link, closed on drop
 }
 
 fn prog_fd<P: AsFd>(prog: &P) -> i32 {
@@ -220,7 +221,7 @@ impl<'a> Scheduler<'a> {
 
         // Initialize skel
         skel.maps.rodata_data.nr_cpus = opts.num_cpus;
-		skel.maps.rodata_data.nr_vcpus = vm_config.iter().map(|vm| vm.vcpus.len() as u32).sum(); 
+        skel.maps.rodata_data.nr_vcpus = vm_config.iter().map(|vm| vm.vcpus.len() as u32).sum();
         skel.maps.rodata_data.nr_vms = vm_config.len() as u32;
         // skel.maps.rodata_data.timer_interval_ns = opts.timer_interval * 1000;
         for (i, vm) in vm_config.iter().enumerate() {
@@ -233,56 +234,75 @@ impl<'a> Scheduler<'a> {
 
         let mut skel = scx_ops_load!(skel, rorke, uei)?;
 
-		// This needs to be initalized after skel is loaded to get valid prog fds
-		let mut sched_metrics: Vec<SchedMetric> = vec![
-			SchedMetric {
-				name: "llc_misses".to_string(), // Human-readable label
-				event_type: sys::bindings::PERF_TYPE_RAW,
-				config: 0x412E, // raw event code for longest_lat_cache.miss. Source: https://github.com/intel/perfmon/blob/main/SKL/events/skylake_core.json#L953
-				sample_period: 100_000,
-				prog_fd: prog_fd(&skel.progs.count_llc_misses),
-				link_fds: vec![],
-			},
-		];
+        // This needs to be initalized after skel is loaded to get valid prog fds
+        let mut sched_metrics: Vec<SchedMetric> = vec![SchedMetric {
+            name: "llc_misses".to_string(), // Human-readable label
+            event_type: sys::bindings::PERF_TYPE_RAW,
+            config: 0x412E, // raw event code for longest_lat_cache.miss. Source: https://github.com/intel/perfmon/blob/main/SKL/events/skylake_core.json#L953
+            sample_period: 100_000,
+            prog_fd: prog_fd(&skel.progs.count_llc_misses),
+            perf_fds: vec![],
+            link_fds: vec![],
+        }];
 
         for cpu in 0..opts.num_cpus {
-			for metric in sched_metrics.iter_mut() {
-				let mut attrs = sys::bindings::perf_event_attr::default();
-				attrs.size = std::mem::size_of::<sys::bindings::perf_event_attr>() as u32;
-				attrs.type_ = metric.event_type;
-				attrs.set_disabled(1);
-				attrs.set_exclude_kernel(1);
-				attrs.set_exclude_hv(1);
-				attrs.config = metric.config;
-				attrs.__bindgen_anon_1.sample_period = metric.sample_period;
-				let perf_fd = unsafe {
-					sys::perf_event_open(&mut attrs, -1, cpu as i32, -1, 0)
-				};
-				if perf_fd < 0 {
-					return Err(anyhow!("Cannot open perf event for pcpu {:?} metric {:?}", cpu, metric.name));
-				}
-				// Create link between perf event and BPF program
-				let link_fd = unsafe {
-					libbpf_sys::bpf_link_create(
-						metric.prog_fd,
-						perf_fd,
-						libbpf_sys::BPF_PERF_EVENT as u32,
-						std::ptr::null(),
-					)
-				};
-				if link_fd < 0 {
-					return Err(anyhow!("Failed to create perf event link for CPU {} metric {:?}", cpu, metric.name));
-				}
-				// Enable the perf event
-				let enable_rc = unsafe {
-					libc::ioctl(perf_fd, 0x2400, 0)
-				};
-				if enable_rc != 0 {
-					return Err(anyhow!("Failed to enable perf event for CPU {} metric {:?}", cpu, metric.name));
-				}
+            for metric in sched_metrics.iter_mut() {
+                let mut attrs = sys::bindings::perf_event_attr::default();
+                attrs.size = std::mem::size_of::<sys::bindings::perf_event_attr>() as u32;
+                attrs.type_ = metric.event_type;
+                attrs.set_disabled(1);
+                attrs.set_exclude_kernel(1);
+                attrs.set_exclude_hv(1);
+                attrs.config = metric.config;
+                // attrs.set_freq(1);
+                // attrs.__bindgen_anon_1.sample_freq = 1;
+                attrs.__bindgen_anon_1.sample_period = metric.sample_period;
+                let perf_fd = unsafe { sys::perf_event_open(&mut attrs, -1, cpu as i32, -1, 0) };
+                if perf_fd < 0 {
+                    return Err(anyhow!(
+                        "Cannot open perf event for pcpu {:?} metric {:?}",
+                        cpu,
+                        metric.name
+                    ));
+                }
+                // Create link between perf event and BPF program
+                let link_fd = unsafe {
+                    libbpf_sys::bpf_link_create(
+                        metric.prog_fd,
+                        perf_fd,
+                        libbpf_sys::BPF_PERF_EVENT as u32,
+                        std::ptr::null(),
+                    )
+                };
+                if link_fd < 0 {
+                    return Err(anyhow!(
+                        "Failed to create perf event link for CPU {} metric {:?}",
+                        cpu,
+                        metric.name
+                    ));
+                }
+                // Reset the perf event's counter to zero
+                let reset_rc = unsafe { libc::ioctl(perf_fd, 0x2401, 0) };
+                if reset_rc != 0 {
+                    return Err(anyhow!(
+                        "Failed to reset perf event for CPU {} metric {:?}",
+                        cpu,
+                        metric.name
+                    ));
+                }
+                // Enable the perf event
+                let enable_rc = unsafe { libc::ioctl(perf_fd, 0x2400, 0) };
+                if enable_rc != 0 {
+                    return Err(anyhow!(
+                        "Failed to enable perf event for CPU {} metric {:?}",
+                        cpu,
+                        metric.name
+                    ));
+                }
 
-				metric.link_fds.push(link_fd);
-			}
+                metric.perf_fds.push(perf_fd);
+                metric.link_fds.push(link_fd);
+            }
         }
 
         initialize_cpu_ctxs(&skel, &cpu_allocation)?;
@@ -350,7 +370,7 @@ impl<'a> Scheduler<'a> {
             skel,
             struct_ops,
             stats_server,
-			sched_metrics,
+            sched_metrics,
         })
     }
 
@@ -389,15 +409,20 @@ impl<'a> Scheduler<'a> {
 impl<'a> Drop for Scheduler<'a> {
     fn drop(&mut self) {
         info!("Unregister {} scheduler", SCHEDULER_NAME);
-        
+
         // Clean up perf links
-		for metric in self.sched_metrics.iter() {
-			for link_fd in metric.link_fds.iter() {
-				unsafe {
-					libc::close(*link_fd);
-				}
-			}
-		}
+        for metric in self.sched_metrics.iter() {
+            for perf_fd in metric.perf_fds.iter() {
+                unsafe {
+                    libc::close(*perf_fd);
+                }
+            }
+            for link_fd in metric.link_fds.iter() {
+                unsafe {
+                    libc::close(*link_fd);
+                }
+            }
+        }
     }
 }
 

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -238,8 +238,8 @@ impl<'a> Scheduler<'a> {
         let mut sched_metrics: Vec<SchedMetric> = vec![SchedMetric {
             name: "llc_misses".to_string(), // Human-readable label
             event_type: sys::bindings::PERF_TYPE_RAW,
-            config: 0x412E, // raw event code for longest_lat_cache.miss. Source: https://github.com/intel/perfmon/blob/main/SKL/events/skylake_core.json#L953
-            sample_period: 100_000,
+            config: 0x02A3, // raw event code for cycle_activity.stalls_l3_miss. Source: https://github.com/intel/perfmon/blob/main/ICL/events/icelake_core.json#L3061
+            sample_period: 500_000,
             prog_fd: prog_fd(&skel.progs.count_llc_misses),
             perf_fds: vec![],
             link_fds: vec![],

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -239,7 +239,7 @@ impl<'a> Scheduler<'a> {
 				name: "llc_misses".to_string(), // Human-readable label
 				event_type: sys::bindings::PERF_TYPE_RAW,
 				config: 0x412E, // raw event code for longest_lat_cache.miss. Source: https://github.com/intel/perfmon/blob/main/SKL/events/skylake_core.json#L953
-				sample_period: 10_000,
+				sample_period: 100_000,
 				prog_fd: prog_fd(&skel.progs.count_llc_misses),
 				link_fds: vec![],
 			},

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -17,8 +17,8 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
-use std::process::Command;
 use libc::{sched_param, sched_setscheduler};
+use std::process::Command;
 
 use anyhow::anyhow;
 use anyhow::Context;
@@ -225,8 +225,9 @@ impl<'a> Scheduler<'a> {
             let vcpus = &vm.vcpus;
             debug!("vm_id: {:?} vcpus: {:?}", vm.vm_id, vcpus);
 
-			// pCPUs assigned to this VM
-            let pcpus_str = cpu_allocation.iter()
+            // pCPUs assigned to this VM
+            let pcpus_str = cpu_allocation
+                .iter()
                 .enumerate()
                 .filter_map(|(pcpu, owner)| {
                     if *owner == vm.vm_id as u64 {
@@ -238,12 +239,12 @@ impl<'a> Scheduler<'a> {
                 .collect::<Vec<_>>()
                 .join(",");
 
-			if pcpus_str.is_empty() {
-				return Err(anyhow!("No pCPUs allocated for vm_id {:?}", vm.vm_id));
-			}
+            if pcpus_str.is_empty() {
+                return Err(anyhow!("No pCPUs allocated for vm_id {:?}", vm.vm_id));
+            }
 
-			for (vcpu_idx, vcpu_pid) in vcpus.iter().enumerate() {
-				let param = sched_param { sched_priority: 0 };
+            for (vcpu_idx, vcpu_pid) in vcpus.iter().enumerate() {
+                let param = sched_param { sched_priority: 0 };
                 let result = unsafe {
                     sched_setscheduler(*vcpu_pid as i32, SCHED_EXT, &param as *const sched_param)
                 };
@@ -253,24 +254,24 @@ impl<'a> Scheduler<'a> {
                 }
                 debug!("Set SCHED_EXT for vcpu: {:?}", vcpu_pid);
 
-				let status = Command::new("virsh")
-                       .arg("vcpupin")
-                       .arg(vm.vm_name.clone())
-                       .arg(vcpu_idx.to_string())
-                       .arg(&pcpus_str)
-                       .stdout(std::process::Stdio::null()) // Suppress terminal output
-                       .status()
-                       .context("failed to execute virsh vcpupin")?;
+                let status = Command::new("virsh")
+                    .arg("vcpupin")
+                    .arg(vm.vm_name.clone())
+                    .arg(vcpu_idx.to_string())
+                    .arg(&pcpus_str)
+                    .stdout(std::process::Stdio::null()) // Suppress terminal output
+                    .status()
+                    .context("failed to execute virsh vcpupin")?;
 
-				if !status.success() {
-					return Err(anyhow!(
-						"failed to pin vcpu for vm_id {:?} vcpu {} (pcpus={})",
-						vm.vm_id,
-						vcpu_idx,
-						pcpus_str
-					));
-				}
-			}
+                if !status.success() {
+                    return Err(anyhow!(
+                        "failed to pin vcpu for vm_id {:?} vcpu {} (pcpus={})",
+                        vm.vm_id,
+                        vcpu_idx,
+                        pcpus_str
+                    ));
+                }
+            }
         }
 
         // Start Stats server
@@ -378,4 +379,3 @@ fn main() -> Result<()> {
 
     Ok(())
 }
-

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -219,6 +219,7 @@ impl<'a> Scheduler<'a> {
 
         // Initialize skel
         skel.maps.rodata_data.nr_cpus = opts.num_cpus;
+		skel.maps.rodata_data.nr_vcpus = cpu_allocation.len() as u32;
         skel.maps.rodata_data.nr_vms = vm_config.len() as u32;
         // skel.maps.rodata_data.timer_interval_ns = opts.timer_interval * 1000;
         for (i, vm) in vm_config.iter().enumerate() {
@@ -234,17 +235,10 @@ impl<'a> Scheduler<'a> {
 		// This needs to be initalized after skel is loaded to get valid prog fds
 		let mut sched_metrics: Vec<SchedMetric> = vec![
 			SchedMetric {
-				name: "instructions".to_string(),
-				config: sys::bindings::PERF_COUNT_HW_INSTRUCTIONS as u64,
-				sample_period: 100_000,
-				prog_fd: prog_fd(&skel.progs.count_instr),
-				link_fds: vec![],
-			},
-			SchedMetric {
-				name: "cycles".to_string(),
-				config: sys::bindings::PERF_COUNT_HW_CPU_CYCLES as u64,
-				sample_period: 100_000,
-				prog_fd: prog_fd(&skel.progs.count_cycles),
+				name: "llc_misses".to_string(), // Human-readable label
+				config: sys::bindings::LONGEST_LAT_CACHE.MISS as u64,
+				sample_period: 10_000,
+				prog_fd: prog_fd(&skel.progs.count_llc_misses),
 				link_fds: vec![],
 			},
 		];

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -236,14 +236,14 @@ impl<'a> Scheduler<'a> {
 			SchedMetric {
 				name: "instructions".to_string(),
 				config: sys::bindings::PERF_COUNT_HW_INSTRUCTIONS as u64,
-				sample_period: 150_000,
+				sample_period: 100_000,
 				prog_fd: prog_fd(&skel.progs.count_instr),
 				link_fds: vec![],
 			},
 			SchedMetric {
 				name: "cycles".to_string(),
 				config: sys::bindings::PERF_COUNT_HW_CPU_CYCLES as u64,
-				sample_period: 75_000,
+				sample_period: 100_000,
 				prog_fd: prog_fd(&skel.progs.count_cycles),
 				link_fds: vec![],
 			},

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
 
+use std::process::Command;
 use libc::{sched_param, sched_setscheduler};
 
 use anyhow::anyhow;
@@ -224,17 +225,52 @@ impl<'a> Scheduler<'a> {
             let vcpus = &vm.vcpus;
             debug!("vm_id: {:?} vcpus: {:?}", vm.vm_id, vcpus);
 
-            for vcpu in vcpus.iter() {
-                let param = sched_param { sched_priority: 0 };
+			// pCPUs assigned to this VM
+            let pcpus_str = cpu_allocation.iter()
+                .enumerate()
+                .filter_map(|(pcpu, owner)| {
+                    if *owner == vm.vm_id as u64 {
+                        Some(pcpu.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+
+			if pcpus_str.is_empty() {
+				return Err(anyhow!("No pCPUs allocated for vm_id {:?}", vm.vm_id));
+			}
+
+			for (vcpu_idx, vcpu_pid) in vcpus.iter().enumerate() {
+				let param = sched_param { sched_priority: 0 };
                 let result = unsafe {
-                    sched_setscheduler(*vcpu as i32, SCHED_EXT, &param as *const sched_param)
+                    sched_setscheduler(*vcpu_pid as i32, SCHED_EXT, &param as *const sched_param)
                 };
 
                 if result == -1 {
-                    return Err(anyhow!("Failed to set SCHED_EXT for vcpu: {:?}", vcpu));
+                    return Err(anyhow!("Failed to set SCHED_EXT for vcpu: {:?}", vcpu_pid));
                 }
-                debug!("Set SCHED_EXT for vcpu: {:?}", vcpu);
-            }
+                debug!("Set SCHED_EXT for vcpu: {:?}", vcpu_pid);
+
+				let status = Command::new("virsh")
+                       .arg("vcpupin")
+                       .arg(vm.vm_name.clone())
+                       .arg(vcpu_idx.to_string())
+                       .arg(&pcpus_str)
+                       .stdout(std::process::Stdio::null()) // Suppress terminal output
+                       .status()
+                       .context("failed to execute virsh vcpupin")?;
+
+				if !status.success() {
+					return Err(anyhow!(
+						"failed to pin vcpu for vm_id {:?} vcpu {} (pcpus={})",
+						vm.vm_id,
+						vcpu_idx,
+						pcpus_str
+					));
+				}
+			}
         }
 
         // Start Stats server
@@ -342,3 +378,4 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -171,6 +171,7 @@ fn initialize_cpu_ctxs(skel: &BpfSkel, cpu_allocation: &Vec<u64>) -> Result<()> 
 
 struct SchedMetric {
     name: String, // human-readable label
+	event_type: u32, // PERF_TYPE_HARDWARE, PERF_TYPE_RAW, etc.
     config: u64, // what to count, e.g. PERF_COUNT_HW_INSTRUCTIONS
     sample_period: u64, // perf event is triggered every sample_period counts
     prog_fd: i32, // fd of the BPF program to attach
@@ -219,7 +220,7 @@ impl<'a> Scheduler<'a> {
 
         // Initialize skel
         skel.maps.rodata_data.nr_cpus = opts.num_cpus;
-		skel.maps.rodata_data.nr_vcpus = cpu_allocation.len() as u32;
+		skel.maps.rodata_data.nr_vcpus = vm_config.iter().map(|vm| vm.vcpus.len() as u32).sum(); 
         skel.maps.rodata_data.nr_vms = vm_config.len() as u32;
         // skel.maps.rodata_data.timer_interval_ns = opts.timer_interval * 1000;
         for (i, vm) in vm_config.iter().enumerate() {
@@ -236,7 +237,8 @@ impl<'a> Scheduler<'a> {
 		let mut sched_metrics: Vec<SchedMetric> = vec![
 			SchedMetric {
 				name: "llc_misses".to_string(), // Human-readable label
-				config: sys::bindings::LONGEST_LAT_CACHE.MISS as u64,
+				event_type: sys::bindings::PERF_TYPE_RAW,
+				config: 0x412E, // raw event code for longest_lat_cache.miss. Source: https://github.com/intel/perfmon/blob/main/SKL/events/skylake_core.json#L953
 				sample_period: 10_000,
 				prog_fd: prog_fd(&skel.progs.count_llc_misses),
 				link_fds: vec![],
@@ -247,7 +249,7 @@ impl<'a> Scheduler<'a> {
 			for metric in sched_metrics.iter_mut() {
 				let mut attrs = sys::bindings::perf_event_attr::default();
 				attrs.size = std::mem::size_of::<sys::bindings::perf_event_attr>() as u32;
-				attrs.type_ = sys::bindings::PERF_TYPE_HARDWARE;
+				attrs.type_ = metric.event_type;
 				attrs.set_disabled(1);
 				attrs.set_exclude_kernel(1);
 				attrs.set_exclude_hv(1);

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -16,6 +16,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::time::Duration;
+use std::os::fd::{AsFd, AsRawFd};
 
 use libc::{sched_param, sched_setscheduler};
 use std::process::Command;
@@ -34,6 +35,8 @@ use libbpf_rs::OpenObject;
 
 use log::debug;
 use log::info;
+
+use perf_event_open_sys as sys;
 
 use scx_stats::prelude::*;
 
@@ -170,6 +173,7 @@ struct Scheduler<'a> {
     skel: BpfSkel<'a>,
     struct_ops: Option<libbpf_rs::Link>,
     stats_server: StatsServer<(), Metrics>,
+    perf_links: Vec<i32>,
 }
 
 impl<'a> Scheduler<'a> {
@@ -214,6 +218,49 @@ impl<'a> Scheduler<'a> {
         skel.maps.rodata_data.debug = opts.verbose as u32;
 
         let mut skel = scx_ops_load!(skel, rorke, uei)?;
+
+        let mut perf_links = Vec::<i32>::new();
+        for cpu in 0..opts.num_cpus {
+            let mut attrs = sys::bindings::perf_event_attr::default();
+            attrs.size = std::mem::size_of::<sys::bindings::perf_event_attr>() as u32;
+            attrs.type_ = sys::bindings::PERF_TYPE_HARDWARE;
+            attrs.set_disabled(1);
+            attrs.set_exclude_kernel(1);
+            attrs.set_exclude_hv(1);
+			attrs.__bindgen_anon_1.sample_period = 100; // perf event triggers every sample_period instructions
+			attrs.config = sys::bindings::PERF_COUNT_HW_INSTRUCTIONS as u64;
+
+            let perf_fd = unsafe {
+                sys::perf_event_open(&mut attrs, -1, cpu as i32, -1, 0)
+            };
+            if perf_fd < 0 {
+                return Err(anyhow!("Cannot open perf instructions event for pcpu {:?}", cpu));
+            }
+			// Fd of the BPF program to attach
+            let prog_fd = skel.progs.on_perf_event.as_fd().as_raw_fd();
+            // Create link between perf event and BPF program
+            let link_fd = unsafe {
+                libbpf_sys::bpf_link_create(
+                    prog_fd,
+                    perf_fd,
+                    libbpf_sys::BPF_PERF_EVENT as u32,
+                    std::ptr::null(),
+                )
+            };
+            if link_fd < 0 {
+                return Err(anyhow!("Failed to create perf event link for CPU {}", cpu));
+            }
+
+			// Enable the perf event
+            let enable_rc = unsafe {
+                libc::ioctl(perf_fd, 0x2400, 0)
+            };
+            if enable_rc != 0 {
+                return Err(anyhow!("Failed to enable perf event for CPU {}", cpu));
+            }
+
+            perf_links.push(link_fd);
+        }
 
         initialize_cpu_ctxs(&skel, &cpu_allocation)?;
 
@@ -280,6 +327,7 @@ impl<'a> Scheduler<'a> {
             skel,
             struct_ops,
             stats_server,
+            perf_links,
         })
     }
 
@@ -318,6 +366,13 @@ impl<'a> Scheduler<'a> {
 impl<'a> Drop for Scheduler<'a> {
     fn drop(&mut self) {
         info!("Unregister {} scheduler", SCHEDULER_NAME);
+        
+        // Clean up perf links
+        for &link_fd in self.perf_links.iter() {
+            unsafe {
+                libc::close(link_fd);
+            }
+        }
     }
 }
 

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -236,14 +236,14 @@ impl<'a> Scheduler<'a> {
 			SchedMetric {
 				name: "instructions".to_string(),
 				config: sys::bindings::PERF_COUNT_HW_INSTRUCTIONS as u64,
-				sample_period: 1_000,
+				sample_period: 150_000,
 				prog_fd: prog_fd(&skel.progs.count_instr),
 				link_fds: vec![],
 			},
 			SchedMetric {
 				name: "cycles".to_string(),
 				config: sys::bindings::PERF_COUNT_HW_CPU_CYCLES as u64,
-				sample_period: 1_000,
+				sample_period: 75_000,
 				prog_fd: prog_fd(&skel.progs.count_cycles),
 				link_fds: vec![],
 			},

--- a/scheds/rust/scx_rorke/src/main.rs
+++ b/scheds/rust/scx_rorke/src/main.rs
@@ -220,7 +220,7 @@ impl<'a> Scheduler<'a> {
         // Initialize skel
         skel.maps.rodata_data.nr_cpus = opts.num_cpus;
         skel.maps.rodata_data.nr_vms = vm_config.len() as u32;
-        skel.maps.rodata_data.timer_interval_ns = opts.timer_interval * 1000;
+        // skel.maps.rodata_data.timer_interval_ns = opts.timer_interval * 1000;
         for (i, vm) in vm_config.iter().enumerate() {
             skel.maps.rodata_data.vms[i] = vm.vm_id;
         }


### PR DESCRIPTION
The vCPUs are now automatically assigned to the pCPUs of their VM.
Tried to implement this using affinity syscalls but they don't work that well for VMs.
Ended up using `virsh` commands.